### PR TITLE
Add LLM helpers and fake extractor tests

### DIFF
--- a/t008_meeting_snap/llm.py
+++ b/t008_meeting_snap/llm.py
@@ -1,0 +1,84 @@
+"""LLM integration helpers for Meeting Snap."""
+from __future__ import annotations
+
+import json
+import re
+import textwrap
+from typing import Any, Dict
+
+_PROMPT_TEMPLATE = textwrap.dedent(
+    """
+    You are Meeting Snap, an assistant that extracts meeting outcomes for busy
+    teams. Read the transcript and respond with a JSON object that matches the
+    following schema:
+    {
+      "decisions": ["short summary", ... up to 10 items],
+      "actions": [
+        {"action": "task", "owner": "Name or null", "due": "Due date or null"}
+      ],
+      "questions": ["open question"],
+      "risks": ["issue or blocker"],
+      "next_checkin": "describe the next meeting or null"
+    }
+
+    Rules:
+    - Trim whitespace from every string you return and keep them concise.
+    - If a field has no content, use an empty list or null for "next_checkin".
+    - The JSON must be valid and parsable without additional commentary.
+
+    Transcript:
+    ---
+    {transcript}
+    ---
+    """
+)
+
+
+_DEFENSIVE_DECODER = json.JSONDecoder()
+_CODE_FENCE_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL | re.IGNORECASE)
+
+
+def build_prompt(transcript: str) -> str:
+    """Return the LLM prompt for a given transcript snippet."""
+
+    clean_transcript = transcript.strip() if transcript else ""
+    if not clean_transcript:
+        clean_transcript = "(No transcript content provided.)"
+    return _PROMPT_TEMPLATE.format(transcript=clean_transcript)
+
+
+def _decode_candidate(snippet: str) -> Dict[str, Any] | None:
+    try:
+        payload = json.loads(snippet)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def parse_json_block(text: str) -> Dict[str, Any]:
+    """Extract and parse the first JSON object embedded in ``text``."""
+
+    direct = _decode_candidate(text.strip())
+    if direct is not None:
+        return direct
+
+    for match in _CODE_FENCE_RE.finditer(text):
+        candidate = _decode_candidate(match.group(1).strip())
+        if candidate is not None:
+            return candidate
+
+    start = 0
+    while True:
+        brace = text.find("{", start)
+        if brace == -1:
+            break
+        try:
+            payload, offset = _DEFENSIVE_DECODER.raw_decode(text[brace:])
+        except json.JSONDecodeError:
+            start = brace + 1
+            continue
+        if isinstance(payload, dict):
+            return payload
+        start = brace + offset
+
+    raise ValueError("No JSON object found in text")

--- a/t008_meeting_snap/llm_fake.py
+++ b/t008_meeting_snap/llm_fake.py
@@ -1,0 +1,24 @@
+"""Deterministic fake LLM extractor used in unit tests."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .schema import empty_snapshot
+
+
+def extract(transcript: str) -> Dict[str, Any]:
+    """Return a predictable schema-valid snapshot for testing."""
+
+    snapshot = empty_snapshot()
+    snapshot["decisions"] = ["Use the fake LLM output for validation"]
+    snapshot["actions"] = [
+        {
+            "action": "Share meeting notes with the wider team",
+            "owner": "Alex",
+            "due": "Next Monday",
+        }
+    ]
+    snapshot["questions"] = ["Any blockers before launch?"]
+    snapshot["risks"] = ["Timeline depends on vendor availability."]
+    snapshot["next_checkin"] = "Next Tuesday"
+    return snapshot

--- a/tests/tests_fake.py
+++ b/tests/tests_fake.py
@@ -1,0 +1,36 @@
+"""Tests for the deterministic fake LLM adapter."""
+from __future__ import annotations
+
+from t008_meeting_snap import llm_fake
+from t008_meeting_snap.schema import validate_snapshot
+
+
+def test_llm_fake_extract_produces_valid_snapshot() -> None:
+    raw = llm_fake.extract("Team decided to adopt the new process.")
+    snapshot = validate_snapshot(raw)
+
+    assert set(snapshot.keys()) == {
+        "decisions",
+        "actions",
+        "questions",
+        "risks",
+        "next_checkin",
+    }
+    assert snapshot["decisions"] and all(isinstance(item, str) for item in snapshot["decisions"])
+
+    assert snapshot["actions"] and isinstance(snapshot["actions"], list)
+    action = snapshot["actions"][0]
+    assert set(action.keys()) == {"action", "owner", "due"}
+    assert isinstance(action["action"], str) and action["action"].strip()
+    owner = action["owner"]
+    assert owner is None or (isinstance(owner, str) and owner.strip())
+    due = action["due"]
+    assert due is None or (isinstance(due, str) and due.strip())
+
+    assert snapshot["questions"] and all(
+        isinstance(item, str) and item.strip() for item in snapshot["questions"]
+    )
+    assert snapshot["risks"] and all(
+        isinstance(item, str) and item.strip() for item in snapshot["risks"]
+    )
+    assert snapshot["next_checkin"] is None or isinstance(snapshot["next_checkin"], str)


### PR DESCRIPTION
## Summary
- add utilities for crafting the LLM prompt and parsing JSON responses
- provide a deterministic fake extractor that returns schema-valid payloads
- verify the fake extractor integrates with schema validation via a new test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca4db26b408326b536259a096216cc