### PR TITLE
Add safety utilities and rate limiting

### DIFF
--- a/t008_meeting_snap/safety.py
+++ b/t008_meeting_snap/safety.py
@@ -1,0 +1,57 @@
+"""Safety helpers for truncation, logging, and rate limiting."""
+from __future__ import annotations
+
+import time
+from collections import deque
+from threading import Lock
+from typing import Deque, Dict
+
+
+def truncate(value: str, limit: int) -> str:
+    """Return ``value`` limited to ``limit`` characters."""
+
+    if limit <= 0:
+        return ""
+    if len(value) <= limit:
+        return value
+    return value[:limit]
+
+
+def sanitize_for_log(value: str, *, limit: int = 256) -> str:
+    """Return a printable, length-limited string safe for logging."""
+
+    sanitized = value.replace("\r", " ").replace("\n", " ")
+    sanitized = " ".join(sanitized.split())
+    sanitized = "".join(ch for ch in sanitized if ch.isprintable())
+    return truncate(sanitized, limit)
+
+
+class RateLimiter:
+    """In-memory sliding window rate limiter."""
+
+    def __init__(self, max_requests: int, window_seconds: float) -> None:
+        if max_requests < 0:
+            raise ValueError("max_requests must be non-negative")
+        if window_seconds <= 0:
+            raise ValueError("window_seconds must be positive")
+
+        self.max_requests = max_requests
+        self.window_seconds = window_seconds
+        self._events: Dict[str, Deque[float]] = {}
+        self._lock = Lock()
+
+    def allow(self, identity: str, *, now: float | None = None) -> bool:
+        """Return True if the request identified by ``identity`` is allowed."""
+
+        if self.max_requests == 0:
+            return False
+        timestamp = time.monotonic() if now is None else now
+        with self._lock:
+            events = self._events.setdefault(identity, deque())
+            cutoff = timestamp - self.window_seconds
+            while events and events[0] <= cutoff:
+                events.popleft()
+            if len(events) >= self.max_requests:
+                return False
+            events.append(timestamp)
+            return True

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,24 @@
+"""Rate limiting behavior for the Meeting Snap app."""
+from __future__ import annotations
+
+from t008_meeting_snap.app import app
+from t008_meeting_snap.safety import RateLimiter
+
+app.config.update(TESTING=True)
+
+
+def test_snap_post_rate_limited(monkeypatch) -> None:
+    """Rapid submissions from the same IP yield a 429 response."""
+
+    monkeypatch.setenv("MEETING_SNAP_PROVIDER", "fake")
+    limiter = RateLimiter(max_requests=2, window_seconds=60.0)
+    monkeypatch.setitem(app.config, "RATE_LIMITER", limiter)
+
+    with app.test_client() as client:
+        first = client.post("/snap", data={"transcript": "Quarterly sync"})
+        second = client.post("/snap", data={"transcript": "Quarterly sync"})
+        third = client.post("/snap", data={"transcript": "Quarterly sync"})
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert third.status_code == 429


### PR DESCRIPTION
## Summary
- add safety helpers to truncate user input, sanitize log messages, and limit request bursts
- enforce input truncation and rate limiting in the `/snap` endpoint with a 429 response when exceeded
- cover the new rate limiting behaviour with a dedicated test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca78ca21308326ab35b7d2f5f8aad3