### PR TITLE
Add truthful model assist badge and fallback banner

### DIFF
--- a/t008_meeting_snap/app.py
+++ b/t008_meeting_snap/app.py
@@ -32,13 +32,22 @@ def _render_page(
     error: str | None,
     provider: str,
     max_chars: int,
+    *,
+    model_assist_used: bool = False,
+    model_assist_attempted: bool = False,
 ) -> str:
+    assist_requested = _model_assist_enabled(provider)
+    assist_note = None
+    if model_assist_attempted and assist_requested and not model_assist_used:
+        assist_note = "Model assist unavailable—using baseline."
+
     return render_template(
         "index.html",
         transcript=transcript,
         snapshot=snapshot,
         error=error,
-        model_assist=_model_assist_enabled(provider),
+        model_assist=model_assist_used,
+        model_assist_note=assist_note,
         max_chars=max_chars,
     )
 
@@ -123,13 +132,15 @@ def snap() -> str:
         )
 
     timeout_ms = config.get_timeout_ms()
-    snapshot = extractor.extract_snapshot(transcript, provider, timeout_ms)
+    snapshot, used_model_assist = extractor.extract_snapshot(transcript, provider, timeout_ms)
     return _render_page(
         transcript=transcript,
         snapshot=snapshot,
         error=None,
         provider=provider,
         max_chars=max_chars,
+        model_assist_used=used_model_assist,
+        model_assist_attempted=True,
     )
 
 

--- a/t008_meeting_snap/templates/index.html
+++ b/t008_meeting_snap/templates/index.html
@@ -48,6 +48,11 @@
         margin-bottom: 1.5rem;
         font-weight: 600;
       }
+      .banner.warning {
+        background: #ffe8d9;
+        border-color: #f3a86f;
+        color: #8a3b0d;
+      }
       .status {
         margin: 0 0 0.75rem 0;
       }
@@ -116,6 +121,9 @@
         Model assist: {{ 'ON' if model_assist else 'OFF' }}
       </span>
     </div>
+    {% if model_assist_note %}
+      <div class="banner warning">{{ model_assist_note }}</div>
+    {% endif %}
     <div class="banner">Don’t paste regulated/PII.</div>
     <p class="privacy-note"><strong>Privacy note:</strong> Snapshots may use AI assistance. Avoid sharing confidential or personal data.</p>
     <form action="{{ url_for('snap') }}" method="post">


### PR DESCRIPTION
## Summary
- track whether extractor succeeded with a provider and expose the flag to the UI
- render a fallback notice when model assist was requested but baseline output was used
- keep the existing badge but drive it from the actual usage flag

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca887193a883269bfbfac061b4adc3