### PR TITLE
Make rate limiter configurable via environment

### DIFF
--- a/t008_meeting_snap/app.py
+++ b/t008_meeting_snap/app.py
@@ -13,12 +13,9 @@ from .safety import RateLimiter, sanitize_for_log, truncate
 logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
-
-_DEFAULT_RATE_LIMIT_REQUESTS = 60
-_DEFAULT_RATE_LIMIT_WINDOW_SECONDS = 60.0
 app.config.setdefault(
     "RATE_LIMITER",
-    RateLimiter(_DEFAULT_RATE_LIMIT_REQUESTS, _DEFAULT_RATE_LIMIT_WINDOW_SECONDS),
+    RateLimiter(config.get_rate_limit(), config.get_rate_window_s()),
 )
 
 
@@ -57,9 +54,9 @@ def _get_rate_limiter() -> RateLimiter:
     if isinstance(limiter, RateLimiter):
         return limiter
 
-    requests_limit = int(app.config.get("RATE_LIMIT_REQUESTS", _DEFAULT_RATE_LIMIT_REQUESTS))
+    requests_limit = int(app.config.get("RATE_LIMIT_REQUESTS", config.get_rate_limit()))
     window_seconds = float(
-        app.config.get("RATE_LIMIT_WINDOW_SECONDS", _DEFAULT_RATE_LIMIT_WINDOW_SECONDS)
+        app.config.get("RATE_LIMIT_WINDOW_SECONDS", config.get_rate_window_s())
     )
     limiter = RateLimiter(requests_limit, window_seconds)
     app.config["RATE_LIMITER"] = limiter

--- a/t008_meeting_snap/config.py
+++ b/t008_meeting_snap/config.py
@@ -6,6 +6,8 @@ import os
 _DEFAULT_PROVIDER = "logic"
 _DEFAULT_TIMEOUT_MS = 10_000
 _DEFAULT_MAX_CHARS = 8000
+_DEFAULT_RATE_LIMIT = 30
+_DEFAULT_RATE_WINDOW_S = 86_400
 _DEFAULT_OPENAI_MODEL = "gpt-4o-mini"
 
 
@@ -39,6 +41,18 @@ def get_max_chars() -> int:
     """Return the maximum allowed transcript length in characters."""
 
     return _read_int("MEETING_SNAP_MAX_CHARS", _DEFAULT_MAX_CHARS)
+
+
+def get_rate_limit() -> int:
+    """Return the maximum number of requests allowed per rate window."""
+
+    return _read_int("MEETING_SNAP_RATE_LIMIT", _DEFAULT_RATE_LIMIT)
+
+
+def get_rate_window_s() -> int:
+    """Return the rate limiting window duration in seconds."""
+
+    return _read_int("MEETING_SNAP_RATE_WINDOW_S", _DEFAULT_RATE_WINDOW_S)
 
 
 def get_openai_model() -> str:


### PR DESCRIPTION
## Summary
- add configuration helpers that expose rate limit and window values with defaults of 30 requests per 24 hours
- initialize the application rate limiter using the configuration helpers so updated environment variables apply on restart

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ca896dac3883269b1b0a8960fb369d