### PR TITLE
Add in-memory metrics and structured logging

### DIFF
--- a/t008_meeting_snap/app.py
+++ b/t008_meeting_snap/app.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 import logging
+import time
 from typing import Mapping
 
 from flask import Flask, Response, render_template, request
 
-from . import config, extractor, schema
+from . import config, extractor, metrics, schema
 from .safety import RateLimiter, sanitize_for_log, truncate
 
 logger = logging.getLogger(__name__)
@@ -79,6 +81,7 @@ def _client_identity() -> str:
 
 @app.get("/")
 def index() -> str:
+    metrics.inc("requests_total")
     provider = config.get_provider()
     max_chars = config.get_max_chars()
     return _render_page(
@@ -91,12 +94,27 @@ def index() -> str:
 
 
 @app.post("/snap")
-def snap() -> str:
+def snap() -> Response | str:
+    metrics.inc("requests_total")
     provider = config.get_provider()
+    provider_id = (provider or "").strip().lower()
     max_chars = config.get_max_chars()
     limiter = _get_rate_limiter()
     identity = _client_identity()
+    raw_transcript = request.form.get("transcript", "")
+    input_chars = len(raw_transcript)
+    truncated = bool(raw_transcript and len(raw_transcript) > max_chars)
+    if truncated:
+        metrics.inc("truncations_total")
+    transcript = truncate(raw_transcript, max_chars)
+
+    used_model_assist = False
+    duration_ms = 0.0
+    tokens: int | None = None
+    fallback_reason: str | None = None
+
     if not limiter.allow(identity):
+        metrics.inc("rate_limit_hits_total")
         logger.warning("Rate limit exceeded for %s", sanitize_for_log(identity))
         body = _render_page(
             transcript="",
@@ -105,40 +123,155 @@ def snap() -> str:
             provider=provider,
             max_chars=max_chars,
         )
+        _log_snap_event(
+            provider_id,
+            used_model_assist,
+            input_chars,
+            truncated,
+            duration_ms,
+            fallback="rate_limit",
+            tokens=tokens,
+        )
         return Response(body, status_code=429)
 
-    raw_transcript = request.form.get("transcript", "")
-    transcript = truncate(raw_transcript, max_chars)
-
     if not transcript:
-        return _render_page(
+        body = _render_page(
             transcript="",
             snapshot=schema.UI_EMPTY,
             error=None,
             provider=provider,
             max_chars=max_chars,
         )
+        _log_snap_event(
+            provider_id,
+            used_model_assist,
+            input_chars,
+            truncated,
+            duration_ms,
+            fallback="empty_input",
+            tokens=tokens,
+        )
+        return body
 
-    if raw_transcript and len(raw_transcript) > max_chars:
-        return _render_page(
+    if truncated:
+        body = _render_page(
             transcript=transcript,
             snapshot=schema.UI_EMPTY,
             error=f"Trim input to {max_chars:,} characters.",
             provider=provider,
             max_chars=max_chars,
         )
+        _log_snap_event(
+            provider_id,
+            used_model_assist,
+            input_chars,
+            truncated,
+            duration_ms,
+            fallback="input_too_long",
+            tokens=tokens,
+        )
+        return body
 
     timeout_ms = config.get_timeout_ms()
+    start_time = time.perf_counter() if provider_id != "logic" else None
     snapshot, used_model_assist = extractor.extract_snapshot(transcript, provider, timeout_ms)
-    return _render_page(
+    if start_time is not None:
+        duration_ms = (time.perf_counter() - start_time) * 1000.0
+        metrics.inc("llm_calls_total")
+        metrics.inc("llm_latency_ms_sum", value=duration_ms)
+
+    path_label = _snap_path_label(provider_id, used_model_assist)
+    if path_label == "fallback" and provider_id != "logic":
+        fallback_reason = "provider_error"
+    metrics.inc("snaps_total", {"path": path_label})
+
+    if used_model_assist and provider_id != "logic":
+        tokens = _approximate_token_usage(transcript, snapshot)
+        if tokens is not None:
+            metrics.inc("llm_tokens_total", value=tokens)
+
+    body = _render_page(
         transcript=transcript,
         snapshot=snapshot,
         error=None,
         provider=provider,
         max_chars=max_chars,
         model_assist_used=used_model_assist,
-        model_assist_attempted=True,
+        model_assist_attempted=provider_id != "logic",
     )
+    _log_snap_event(
+        provider_id,
+        used_model_assist,
+        input_chars,
+        truncated,
+        duration_ms,
+        fallback=fallback_reason,
+        tokens=tokens,
+    )
+    return body
+
+
+@app.get("/metrics")
+def metrics_endpoint() -> Response:
+    metrics.inc("requests_total")
+    payload = metrics.to_prometheus()
+    response = Response(payload)
+    response.content_type = "text/plain; charset=utf-8"
+    return response
+
+
+def _snap_path_label(provider_id: str, used_model_assist: bool) -> str:
+    provider_key = provider_id or "logic"
+    if provider_key == "logic":
+        return "logic"
+    if used_model_assist:
+        if provider_key in {"fake", "openai"}:
+            return provider_key
+        return provider_key
+    return "fallback"
+
+
+def _approximate_token_usage(transcript: str, snapshot: Mapping[str, object]) -> int | None:
+    try:
+        from . import llm
+    except Exception:  # pragma: no cover - defensive import guard
+        return None
+
+    try:
+        prompt = llm.build_prompt(transcript)
+    except Exception:  # pragma: no cover - defensive fall back
+        prompt = transcript or ""
+    try:
+        response = json.dumps(snapshot, ensure_ascii=False, separators=(",", ":"))
+    except (TypeError, ValueError):
+        response = ""
+    approx = int((len(prompt) + len(response)) / 4)
+    return max(approx, 0)
+
+
+def _log_snap_event(
+    provider_id: str,
+    used_model_assist: bool,
+    input_chars: int,
+    truncated: bool,
+    duration_ms: float,
+    *,
+    fallback: str | None,
+    tokens: int | None,
+) -> None:
+    provider_value = sanitize_for_log(provider_id) if provider_id else ""
+    fallback_value = sanitize_for_log(fallback) if fallback else None
+    payload = {
+        "event": "snap",
+        "provider": provider_value,
+        "used_assist": used_model_assist,
+        "input_chars": int(input_chars),
+        "truncated": truncated,
+        "duration_ms": round(duration_ms, 3),
+        "fallback": fallback_value,
+        "tokens": tokens,
+    }
+    logging.info(json.dumps(payload))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/t008_meeting_snap/metrics.py
+++ b/t008_meeting_snap/metrics.py
@@ -1,0 +1,102 @@
+"""Minimal in-memory counters and Prometheus exposition helpers."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, Mapping, Tuple
+
+requests_total: float = 0.0
+rate_limit_hits_total: float = 0.0
+truncations_total: float = 0.0
+llm_calls_total: float = 0.0
+llm_latency_ms_sum: float = 0.0
+llm_tokens_total: float = 0.0
+
+snaps_total: Dict[str, float] = {name: 0.0 for name in ("logic", "fake", "openai", "fallback")}
+
+_other_counters: Dict[str, float] = defaultdict(float)
+_labelled_counters: Dict[str, Dict[Tuple[Tuple[str, str], ...], float]] = defaultdict(
+    lambda: defaultdict(float)
+)
+
+
+def inc(name: str, labels: Mapping[str, str] | None = None, value: float = 1.0) -> None:
+    """Increment the named counter in-memory."""
+
+    global requests_total, rate_limit_hits_total, truncations_total
+    global llm_calls_total, llm_latency_ms_sum, llm_tokens_total
+
+    if labels:
+        if name == "snaps_total":
+            path = labels.get("path", "fallback")
+            snaps_total[path] = snaps_total.get(path, 0.0) + value
+            return
+        label_key = tuple(sorted((str(k), str(v)) for k, v in labels.items()))
+        _labelled_counters[name][label_key] += value
+        return
+
+    if name == "requests_total":
+        requests_total += value
+    elif name == "rate_limit_hits_total":
+        rate_limit_hits_total += value
+    elif name == "truncations_total":
+        truncations_total += value
+    elif name == "llm_calls_total":
+        llm_calls_total += value
+    elif name == "llm_latency_ms_sum":
+        llm_latency_ms_sum += value
+    elif name == "llm_tokens_total":
+        llm_tokens_total += value
+    else:
+        _other_counters[name] += value
+
+
+def to_prometheus() -> str:
+    """Return a Prometheus text exposition payload for the recorded metrics."""
+
+    lines = []
+
+    def add_metric(name: str, metric_value: float, labels: Mapping[str, str] | None = None) -> None:
+        formatted_value = _format_value(metric_value)
+        if labels:
+            label_parts = ",".join(
+                f"{key}=\"{_escape_label_value(value)}\"" for key, value in sorted(labels.items())
+            )
+            lines.append(f"{name}{{{label_parts}}} {formatted_value}")
+        else:
+            lines.append(f"{name} {formatted_value}")
+
+    add_metric("requests_total", requests_total)
+    add_metric("rate_limit_hits_total", rate_limit_hits_total)
+    add_metric("truncations_total", truncations_total)
+    add_metric("llm_calls_total", llm_calls_total)
+    add_metric("llm_latency_ms_sum", llm_latency_ms_sum)
+    add_metric("llm_tokens_total", llm_tokens_total)
+
+    for path, count in sorted(snaps_total.items()):
+        add_metric("snaps_total", count, {"path": path})
+
+    for name, value in sorted(_other_counters.items()):
+        add_metric(name, value)
+
+    for name, entries in sorted(_labelled_counters.items()):
+        for label_key, value in sorted(entries.items()):
+            labels = {key: str(val) for key, val in label_key}
+            add_metric(name, value, labels)
+
+    return "\n".join(lines) + "\n"
+
+
+def _format_value(value: float) -> str:
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        if value.is_integer():
+            return str(int(value))
+        return f"{value:.6f}".rstrip("0").rstrip(".")
+    return str(value)
+
+
+def _escape_label_value(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace("\n", "\\n")
+    return escaped.replace('"', '\\"')


### PR DESCRIPTION
## Summary
- add an in-memory metrics module with Prometheus exposition helpers and counters for key events
- increment metrics through the Flask app, approximate token usage, and emit structured snap event logs
- expose a /metrics endpoint alongside existing handlers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca8a1a45d8832685378469b6895f51