### PR TITLE
Add markdown export download feature

### DIFF
--- a/t008_meeting_snap/export.py
+++ b/t008_meeting_snap/export.py
@@ -1,0 +1,100 @@
+"""Utilities for exporting Meeting Snap data to markdown."""
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+from . import schema
+
+_PLACEHOLDER = "—"
+
+
+def to_markdown(snapshot: Mapping[str, object]) -> bytes:
+    """Return a UTF-8 encoded markdown export of ``snapshot``.
+
+    Parameters
+    ----------
+    snapshot:
+        A mapping representing the Meeting Snap summary structure.
+    """
+
+    normalized = _normalize_snapshot(snapshot)
+
+    decisions = _format_string_section(normalized.get("decisions", ()))
+    actions = _format_actions_section(normalized.get("actions", ()))
+    questions = _format_string_section(normalized.get("questions", ()))
+    risks = _format_string_section(normalized.get("risks", ()))
+    next_checkin = _format_single_value(normalized.get("next_checkin"))
+
+    lines = [
+        "# Meeting Snap",
+        "## Decisions",
+        *decisions,
+        "## Actions (owner — due)",
+        *actions,
+        "## Questions",
+        *questions,
+        "## Risks",
+        *risks,
+        "## Next check-in",
+        next_checkin,
+    ]
+
+    markdown = "\n".join(lines) + "\n"
+    return markdown.encode("utf-8")
+
+
+def _normalize_snapshot(snapshot: Mapping[str, object]) -> Mapping[str, object]:
+    if isinstance(snapshot, Mapping):
+        candidate: Mapping[str, object] = dict(snapshot)
+    else:
+        candidate = schema.empty_snapshot()
+    try:
+        return schema.validate_snapshot(candidate)
+    except Exception:
+        return schema.empty_snapshot()
+
+
+def _sanitize(value: str) -> str:
+    collapsed = " ".join(value.replace("\r", "\n").split())
+    return collapsed.strip()
+
+
+def _format_string_section(items: Sequence[str]) -> list[str]:
+    formatted = []
+    for raw in items:
+        text = _sanitize(str(raw))
+        if text:
+            formatted.append(f"- {text}")
+    if not formatted:
+        formatted.append(f"- {_PLACEHOLDER}")
+    return formatted
+
+
+def _format_actions_section(actions: Sequence[Mapping[str, object]]) -> list[str]:
+    formatted = []
+    for item in actions:
+        if not isinstance(item, Mapping):
+            continue
+        action_text = _sanitize(str(item.get("action", ""))) or _PLACEHOLDER
+        owner = item.get("owner")
+        due = item.get("due")
+        owner_text = _sanitize(str(owner)) if isinstance(owner, str) else ""
+        due_text = _sanitize(str(due)) if isinstance(due, str) else ""
+        if not owner_text:
+            owner_text = _PLACEHOLDER
+        if not due_text:
+            due_text = _PLACEHOLDER
+        formatted.append(
+            f"- {action_text} ({owner_text} — {due_text})"
+        )
+    if not formatted:
+        formatted.append(f"- {_PLACEHOLDER}")
+    return formatted
+
+
+def _format_single_value(value: object) -> str:
+    if isinstance(value, str):
+        text = _sanitize(value)
+        if text:
+            return f"- {text}"
+    return f"- {_PLACEHOLDER}"

--- a/t008_meeting_snap/templates/index.html
+++ b/t008_meeting_snap/templates/index.html
@@ -40,6 +40,12 @@
       button:hover {
         background: #00458c;
       }
+      .download-form {
+        margin-bottom: 2rem;
+      }
+      .download-form button {
+        margin-top: 0;
+      }
       .banner {
         background: #fff4cc;
         border: 1px solid #f0c36d;
@@ -135,6 +141,11 @@
     </form>
     {% if error %}
       <div class="error">{{ error }}</div>
+    {% endif %}
+    {% if download_ready %}
+      <form action="{{ url_for('download_markdown') }}" method="get" class="download-form">
+        <button type="submit">Download .md</button>
+      </form>
     {% endif %}
     <div class="results">
       <section>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,18 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+
+from t008_meeting_snap import app as app_module
+
+
+@pytest.fixture(autouse=True)
+def reset_snapshot_cache() -> None:
+    app_module._SNAPSHOT_CACHE.clear()
+    yield
+    app_module._SNAPSHOT_CACHE.clear()

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,37 @@
+"""Tests for the markdown export helper."""
+from __future__ import annotations
+
+from t008_meeting_snap import export
+
+
+def test_to_markdown_formats_sections() -> None:
+    """Markdown export includes every section with fallbacks."""
+
+    snapshot = {
+        "decisions": ["Ship release\nthis week"],
+        "actions": [
+            {"action": "Draft FAQ", "owner": "Taylor", "due": "Friday"},
+            {"action": "Notify customers", "owner": None, "due": None},
+        ],
+        "questions": ["What about billing?"],
+        "risks": [],
+        "next_checkin": "Next Thursday",
+    }
+
+    result = export.to_markdown(snapshot)
+    markdown = result.decode("utf-8")
+
+    expected = """# Meeting Snap\n"""
+    expected += """## Decisions\n"""
+    expected += """- Ship release this week\n"""
+    expected += """## Actions (owner — due)\n"""
+    expected += """- Draft FAQ (Taylor — Friday)\n"""
+    expected += """- Notify customers (— — —)\n"""
+    expected += """## Questions\n"""
+    expected += """- What about billing?\n"""
+    expected += """## Risks\n"""
+    expected += """- —\n"""
+    expected += """## Next check-in\n"""
+    expected += """- Next Thursday\n"""
+
+    assert markdown == expected


### PR DESCRIPTION
## Summary
- add a markdown export helper that formats snapshot sections with sensible fallbacks
- cache the latest snapshot per client, expose a /download.md endpoint, and show a download button in the UI
- cover the new export and download behaviour with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca8d3572f88326aaeefe91b1986091