### PR TITLE
Add focused regression tests

### DIFF
--- a/tests/test_extractor_fallback.py
+++ b/tests/test_extractor_fallback.py
@@ -1,0 +1,25 @@
+"""Ensure the app falls back to baseline extraction on provider errors."""
+
+from t008_meeting_snap import extractor
+from t008_meeting_snap.app import app
+
+app.config.update(TESTING=True)
+
+
+def test_snap_falls_back_when_provider_errors(monkeypatch) -> None:
+    """A provider failure returns a baseline snapshot with the assist note."""
+
+    monkeypatch.setenv("MEETING_SNAP_PROVIDER", "openai")
+
+    def boom(text: str, provider_id: str, timeout_ms: int) -> dict[str, object]:
+        raise RuntimeError("provider failure")
+
+    monkeypatch.setattr(extractor, "_extract_with_provider", boom)
+
+    with app.test_client() as client:
+        response = client.post("/snap", data={"transcript": "Daily sync summary."})
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert "Model assist: OFF" in body
+    assert "Model assist unavailable—using baseline." in body

--- a/tests/test_llm_parse.py
+++ b/tests/test_llm_parse.py
@@ -1,0 +1,38 @@
+"""Focused tests for the JSON parsing helpers."""
+
+import pytest
+
+from t008_meeting_snap.llm import parse_json_block
+
+
+def test_parse_json_block_embedded_object() -> None:
+    """A plain JSON object embedded in prose is extracted."""
+
+    snippet = "Here it is {\"result\": 42, \"status\": \"ok\"} end"
+
+    payload = parse_json_block(snippet)
+
+    assert payload == {"result": 42, "status": "ok"}
+
+
+def test_parse_json_block_with_dirty_wrapping_text() -> None:
+    """Leading and trailing narration does not confuse the parser."""
+
+    text = (
+        "Model output follows.\n"
+        "```json\n"
+        "{\n  \"success\": true,\n  \"items\": [1, 2, 3]\n}\n"
+        "```\n"
+        "Thanks!"
+    )
+
+    payload = parse_json_block(text)
+
+    assert payload == {"success": True, "items": [1, 2, 3]}
+
+
+def test_parse_json_block_raises_without_json() -> None:
+    """If no JSON object is present a ``ValueError`` is raised."""
+
+    with pytest.raises(ValueError):
+        parse_json_block("No structured data here.")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,40 @@
+"""Metrics regression tests to ensure counters stay wired."""
+
+from importlib import reload
+from typing import Any
+
+from t008_meeting_snap import app as app_module
+from t008_meeting_snap import metrics as metrics_module
+
+app_module.app.config.update(TESTING=True)
+
+
+def _collect_metrics(client: Any) -> dict[str, float]:
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    payload: dict[str, float] = {}
+    for line in response.get_data(as_text=True).splitlines():
+        if not line.strip():
+            continue
+        name, value_text = line.split(" ", 1)
+        payload[name] = float(value_text)
+    return payload
+
+
+def test_metrics_increment_after_snap(monkeypatch) -> None:
+    """Fetching metrics around a snap should show counter increases."""
+
+    reload(metrics_module)
+    monkeypatch.setenv("MEETING_SNAP_PROVIDER", "logic")
+
+    with app_module.app.test_client() as client:
+        before = _collect_metrics(client)
+        post_response = client.post("/snap", data={"transcript": "Brief hello."})
+        assert post_response.status_code == 200
+        after = _collect_metrics(client)
+
+    assert after["requests_total"] == before["requests_total"] + 2
+    assert (
+        after['snaps_total{path="logic"}']
+        == before['snaps_total{path="logic"}'] + 1
+    )

--- a/tests/test_template_empty.py
+++ b/tests/test_template_empty.py
@@ -1,0 +1,30 @@
+"""Validate the UI placeholders for empty baseline snapshots."""
+
+from t008_meeting_snap.app import app
+
+app.config.update(TESTING=True)
+
+
+def test_empty_sections_render_placeholders(monkeypatch) -> None:
+    """Posting minimal text renders all sections with the empty marker."""
+
+    monkeypatch.setenv("MEETING_SNAP_PROVIDER", "logic")
+
+    with app.test_client() as client:
+        response = client.post("/snap", data={"transcript": "Hello team."})
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+
+    headings = [
+        "Decisions",
+        "Actions",
+        "Open Questions",
+        "Risks / Blockers",
+        "Next Check-in",
+    ]
+
+    for heading in headings:
+        assert f"<h2>{heading}</h2>" in body
+
+    assert body.count('class="empty">—') == 5


### PR DESCRIPTION
## Summary
- add unit coverage for parse_json_block including error handling
- ensure extractor fallback renders the baseline assist note
- verify empty template sections and metrics counters behave as expected

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ca901321e88326ac5b1d45cf20fbe5