### PR TITLE
Add operations and development guides with quickstart instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # meeting-snap
+
+## Agent Quickstart
+- [Operations guide](docs/OPERATIONS.md)
+- [Development guide](docs/DEVELOPMENT.md)
+
+### Run the app
+```bash
+python -m t008_meeting_snap.app
+```
+
+### Run the tests
+```bash
+python -m pytest
+```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,51 @@
+# Meeting Snap Development Guide
+
+## Repository layout
+- `t008_meeting_snap/app.py` — Flask entry point that wires HTTP routes, enforces rate limiting, and renders templates.
+- `t008_meeting_snap/extractor.py` — Chooses between deterministic logic and provider-backed extraction, handling fallbacks.
+- `t008_meeting_snap/logic.py` — Pure-Python heuristics that parse transcripts into snapshot structures without an LLM.
+- `t008_meeting_snap/llm*.py` — Prompt/response helpers (`llm.py`) plus provider adapters such as `llm_fake.py` and `llm_openai.py`.
+- `t008_meeting_snap/schema.py` — Snapshot validation, normalization, and empty-state helpers shared by the app and providers.
+- `t008_meeting_snap/export.py` — Markdown exporter for cached snapshots.
+- `t008_meeting_snap/metrics.py` — In-memory Prometheus counters surfaced at `/metrics`.
+- `t008_meeting_snap/templates/` — HTML template rendered for both empty and populated snapshots.
+- `tests/` — Pytest suite covering extraction logic, metrics, rate limiting, and template rendering.
+
+## JSON contract
+Snapshots must include:
+- `decisions`: list of up to 10 non-empty strings (≤120 chars each).
+- `actions`: list of dicts with `action` (required string) and optional `owner`/`due` strings or nulls.
+- `questions`: list of non-empty strings.
+- `risks`: list of non-empty strings describing blockers.
+- `next_checkin`: string description or null when unknown.
+
+Use `schema.validate_snapshot()` to normalize data before rendering or exporting. Empty views should use `schema.UI_EMPTY`/`schema.empty_snapshot()` for consistency.
+
+## Run and test locally
+1. Create and activate a virtual environment.
+2. Install development dependencies (pytest for tests, plus `openai` if you plan to exercise the live provider):
+   ```bash
+   python -m pip install --upgrade pip
+   python -m pip install pytest openai
+   ```
+3. Run the web UI with the built-in Flask stub:
+   ```bash
+   python -m t008_meeting_snap.app
+   ```
+4. Execute the test suite:
+   ```bash
+   python -m pytest
+   ```
+
+## Contribution constraints
+- Stick to the Python standard library unless you are integrating an optional provider dependency (e.g., `openai`). Keep new runtime requirements documented.
+- Keep individual modules and additions focused—split work if a file would grow beyond ~160 lines to preserve readability.
+- Preserve existing public names (functions, classes, module-level constants) because tests and the Flask template rely on them.
+- Add or update unit tests for any behavior change, especially around extraction, schema validation, and rate limiting.
+
+## Adding a new provider
+1. Create `t008_meeting_snap/llm_<provider>.py` that exposes an `extract(text: str, timeout_ms: int, ...) -> dict` function returning the snapshot JSON.
+2. Update `_extract_with_provider` in `t008_meeting_snap/extractor.py` to route the provider ID to your new module. Keep the logic fallback in the surrounding `extract_snapshot()` untouched.
+3. Extend `t008_meeting_snap/config.py` if you need additional configuration (e.g., API keys or model names) and document the env vars in `docs/OPERATIONS.md`.
+4. Write provider-specific tests under `tests/` using fakes or fixtures so the suite remains deterministic.
+5. Run `python -m pytest` and ensure `/metrics` reporting still reflects the new provider path via `snaps_total{path="<provider>"}`.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,51 @@
+# Meeting Snap Operations
+
+## What it does
+- Provides a lightweight web UI for turning a meeting transcript into a structured "snapshot" that lists decisions, actions, questions, risks, and the next check-in.
+- Serves summaries generated either by deterministic heuristics (`logic` provider) or an external LLM provider (`fake`, `openai`, or future integrations) with automatic fallback to the logic baseline if model assist fails.
+- Caches the most recent snapshot per client IP so that users can immediately download the rendered Markdown export.
+- Exposes Prometheus-formatted counters to track request volume, provider mix, rate limiting, and LLM usage.
+
+## Endpoints
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/` | Render the transcript form and the current snapshot preview. |
+| POST | `/snap` | Accept a transcript submission, enforce rate limits, call the configured provider, and render the updated snapshot. |
+| GET | `/download.md` | Download the last snapshot for the caller as Markdown, returning 404 when nothing is cached. |
+| GET | `/metrics` | Prometheus metrics for `requests_total`, `snaps_total{path=...}`, rate-limit hits, and LLM latency/token counters. |
+
+## Environment variables
+| Name | Default | Purpose |
+| --- | --- | --- |
+| `MEETING_SNAP_PROVIDER` | `logic` | Provider ID (`logic`, `fake`, `openai`, or another custom provider) used when `/snap` receives input. |
+| `MEETING_SNAP_TIMEOUT_MS` | `10000` | Deadline in milliseconds passed to remote providers. Ignored by the `logic` baseline. |
+| `MEETING_SNAP_MAX_CHARS` | `8000` | Maximum characters accepted from the transcript form. Submissions beyond the limit render an error. |
+| `MEETING_SNAP_RATE_LIMIT` | `30` | Number of `/snap` requests allowed per identity during the configured window. Set to `0` to block all writes. |
+| `MEETING_SNAP_RATE_WINDOW_S` | `86400` | Size of the sliding rate-limit window in seconds. |
+| `OPENAI_MODEL` | `gpt-4o-mini` | OpenAI model name when `MEETING_SNAP_PROVIDER=openai`.
+
+## Runbook
+### LLM provider degraded or unavailable
+1. Confirm alerts by checking `/metrics` for a spike in `snaps_total{path="fallback"}` or drops in `llm_calls_total`/`llm_latency_ms_sum`.
+2. Review application logs for `fallback` reasons or provider-specific errors.
+3. The service already falls back to the `logic` baseline for each affected request. If the provider outage is prolonged, temporarily force logic-only mode (see below) to stop generating failing LLM traffic.
+4. Once the provider is healthy, revert to the original configuration and monitor that `snaps_total{path="fallback"}` returns to baseline.
+
+### Temporary rate-limit increase
+1. Evaluate `/metrics` to confirm rate-limit saturation (`rate_limit_hits_total`).
+2. Pick a new limit/window pair that preserves downstream capacity.
+3. Update `MEETING_SNAP_RATE_LIMIT` and/or `MEETING_SNAP_RATE_WINDOW_S` in the deployment environment. Reloading the process is enough for changes to take effect—the limiter instance is rebuilt from the new config when `/snap` handles the next request.
+4. Monitor `rate_limit_hits_total` to ensure the new ceiling unblocks legitimate traffic.
+5. Remember to roll back the change when demand normalizes.
+
+### Force logic-only mode
+1. Set `MEETING_SNAP_PROVIDER=logic` in the runtime environment. This disables LLM calls and ensures every `/snap` request uses deterministic extraction.
+2. Optionally drop any cached snapshots if you need to avoid stale mixed-provider content.
+3. Notify stakeholders that the UI banner will show "Model assist: OFF" until the provider setting is restored.
+4. When the upstream model is healthy again, revert the provider setting and spot-check `/snap` responses for model-assisted output.
+
+## SLOs
+- **Availability:** 99% of `/snap` requests per day should return HTTP 200. Track this by comparing total requests to 4xx/5xx counts in logs; unexpected spikes in `snaps_total{path="fallback"}` can hint at hidden errors.
+- **Model-assist success:** Maintain at least 95% of snapshots served via LLM providers (`snaps_total{path="openai"}` or other providers) over fallback during a rolling 1-hour window.
+- **Rate limiting:** Keep `rate_limit_hits_total / requests_total` under 1% per hour. Adjust limits or investigate abusive clients when the ratio grows.
+- **Latency:** Average LLM latency (`llm_latency_ms_sum / llm_calls_total`) should stay below the configured timeout. Investigate if the value approaches the `MEETING_SNAP_TIMEOUT_MS` ceiling for prolonged periods.


### PR DESCRIPTION
## Summary
- add focused operations runbook covering endpoints, env vars, and SLOs
- document repository layout, JSON contract, and contribution flow for developers
- link the new docs from the README quickstart with run/test commands

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca920f048c832697f2357596af411c