### PR TITLE
Refresh setup and operations docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,39 @@
 - [Operations guide](docs/OPERATIONS.md)
 - [Development guide](docs/DEVELOPMENT.md)
 
+## Run / Test / Env
+
 ### Install
 ```bash
-pip install -r requirements.txt
-# for tests
-pip install -r requirements-dev.txt
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+# Add development-only tools such as pytest
+python -m pip install -r requirements-dev.txt
 ```
 
-### Run the app
+### Environment
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `MEETING_SNAP_PROVIDER` | `logic` | Extraction backend: `logic` (deterministic), `fake` (static sample), or `openai` (live API). |
+| `MEETING_SNAP_TIMEOUT_MS` | `10000` | Request timeout for provider calls. |
+| `MEETING_SNAP_MAX_CHARS` | `8000` | Maximum characters accepted from the transcript form. |
+| `MEETING_SNAP_RATE_LIMIT` | `30` | Requests allowed per identity during the window. |
+| `MEETING_SNAP_RATE_WINDOW_S` | `86400` | Sliding window size, in seconds, for rate limiting. |
+| `OPENAI_API_KEY` | _required for OpenAI_ | Needed only when `MEETING_SNAP_PROVIDER=openai`; consumed by the `openai` SDK. |
+| `OPENAI_MODEL` | `gpt-4o-mini` | Overrides the OpenAI model used when the provider is `openai`. |
+
+### Run
 ```bash
-python -m t008_meeting_snap.app
+# Serve the UI locally at http://127.0.0.1:5000/
+MEETING_SNAP_PROVIDER=logic python -m t008_meeting_snap.app
+
+# Production-style entry point (matches Procfile)
+gunicorn t008_meeting_snap.app:app --bind 0.0.0.0:$PORT --workers 2 --threads 4
 ```
 
-### Run the tests
+### Test
 ```bash
 python -m pytest
 ```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,51 +1,42 @@
 # Meeting Snap Development Guide
 
-## Repository layout
-- `t008_meeting_snap/app.py` — Flask entry point that wires HTTP routes, enforces rate limiting, and renders templates.
-- `t008_meeting_snap/extractor.py` — Chooses between deterministic logic and provider-backed extraction, handling fallbacks.
-- `t008_meeting_snap/logic.py` — Pure-Python heuristics that parse transcripts into snapshot structures without an LLM.
-- `t008_meeting_snap/llm*.py` — Prompt/response helpers (`llm.py`) plus provider adapters such as `llm_fake.py` and `llm_openai.py`.
-- `t008_meeting_snap/schema.py` — Snapshot validation, normalization, and empty-state helpers shared by the app and providers.
-- `t008_meeting_snap/export.py` — Markdown exporter for cached snapshots.
-- `t008_meeting_snap/metrics.py` — In-memory Prometheus counters surfaced at `/metrics`.
-- `t008_meeting_snap/templates/` — HTML template rendered for both empty and populated snapshots.
-- `tests/` — Pytest suite covering extraction logic, metrics, rate limiting, and template rendering.
+## Repository map
+- `t008_meeting_snap/app.py` – Flask entry point, route handlers, and rate limiting.
+- `t008_meeting_snap/config.py` – Environment variable helpers.
+- `t008_meeting_snap/extractor.py` – Dispatches between `logic`, `fake`, and `openai` providers with automatic fallback.
+- `t008_meeting_snap/logic.py` – Deterministic transcript parser used for the baseline provider and fallbacks.
+- `t008_meeting_snap/llm.py` / `llm_fake.py` / `llm_openai.py` – Prompt helpers and provider adapters.
+- `t008_meeting_snap/schema.py` – Snapshot normalisation and validation helpers.
+- `t008_meeting_snap/export.py` – Markdown exporter for cached snapshots.
+- `t008_meeting_snap/metrics.py` – In-memory counters and Prometheus exposition.
+- `t008_meeting_snap/templates/` – HTML templates rendered by the Flask app.
+- `tests/` – Pytest suite covering the app, schema, metrics, and provider flows.
+- `tests/_stubs/` – Test-only stand-ins for `flask` and `pydantic`. Runtime code must import the real packages.
 
 ## JSON contract
-Snapshots must include:
-- `decisions`: list of up to 10 non-empty strings (≤120 chars each).
-- `actions`: list of dicts with `action` (required string) and optional `owner`/`due` strings or nulls.
-- `questions`: list of non-empty strings.
-- `risks`: list of non-empty strings describing blockers.
-- `next_checkin`: string description or null when unknown.
+Snapshots emitted by providers and rendered in the UI must contain:
 
-Use `schema.validate_snapshot()` to normalize data before rendering or exporting. Empty views should use `schema.UI_EMPTY`/`schema.empty_snapshot()` for consistency.
+| Field | Type | Notes |
+| --- | --- | --- |
+| `decisions` | list[str] | Up to 10 non-empty strings (≤120 characters each). |
+| `actions` | list[dict] | Each item requires `action`; optional `owner`/`due` strings or `None`. |
+| `questions` | list[str] | Non-empty follow-up questions. |
+| `risks` | list[str] | Non-empty risk descriptions. |
+| `next_checkin` | str or None | Human-readable schedule for the next check-in. |
 
-## Run and test locally
-1. Create and activate a virtual environment.
-2. Install development dependencies (pytest for tests, plus `openai` if you plan to exercise the live provider):
-   ```bash
-   python -m pip install --upgrade pip
-   python -m pip install pytest openai
-   ```
-3. Run the web UI with the built-in Flask stub:
-   ```bash
-   python -m t008_meeting_snap.app
-   ```
-4. Execute the test suite:
-   ```bash
-   python -m pytest
-   ```
+Use `schema.validate_snapshot()` to coerce provider output into a valid payload. Empty states should come from `schema.UI_EMPTY` or `schema.empty_snapshot()` so the UI and download export stay in sync.
 
-## Contribution constraints
-- Stick to the Python standard library unless you are integrating an optional provider dependency (e.g., `openai`). Keep new runtime requirements documented.
-- Keep individual modules and additions focused—split work if a file would grow beyond ~160 lines to preserve readability.
-- Preserve existing public names (functions, classes, module-level constants) because tests and the Flask template rely on them.
-- Add or update unit tests for any behavior change, especially around extraction, schema validation, and rate limiting.
+## Local workflow
+1. Follow the README “Run / Test / Env” section to create a virtual environment and install dependencies.
+2. Launch the app with `MEETING_SNAP_PROVIDER=logic python -m t008_meeting_snap.app` and open `http://127.0.0.1:5000/`.
+3. Run `python -m pytest` before sending changes—tests cover the contract, rate limiter, exporter, and HTML output.
 
-## Adding a new provider
-1. Create `t008_meeting_snap/llm_<provider>.py` that exposes an `extract(text: str, timeout_ms: int, ...) -> dict` function returning the snapshot JSON.
-2. Update `_extract_with_provider` in `t008_meeting_snap/extractor.py` to route the provider ID to your new module. Keep the logic fallback in the surrounding `extract_snapshot()` untouched.
-3. Extend `t008_meeting_snap/config.py` if you need additional configuration (e.g., API keys or model names) and document the env vars in `docs/OPERATIONS.md`.
-4. Write provider-specific tests under `tests/` using fakes or fixtures so the suite remains deterministic.
-5. Run `python -m pytest` and ensure `/metrics` reporting still reflects the new provider path via `snaps_total{path="<provider>"}`.
+## Test doubles
+- The stub modules in `tests/_stubs/` keep the test environment isolated from real Flask and pydantic. Add to these stubs when new imports appear in tests.
+- `t008_meeting_snap/app.py` guards against accidentally running with the stubs; keep that check intact when editing imports.
+
+## Coding rules
+- **Standard library first.** Runtime modules must stay within the Python standard library unless you are extending an optional provider integration (e.g. the `openai` dependency already declared in `requirements.txt`). Discuss any new runtime package additions before landing them.
+- Keep modules focused—split large changes if a file would balloon past ~160 lines for readability.
+- Maintain existing public names because the template and tests import them directly.
+- Add or update unit tests when behaviour changes, especially around extraction, schema validation, or rate limiting.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,55 +1,44 @@
 # Meeting Snap Operations
 
-## What it does
-- Provides a lightweight web UI for turning a meeting transcript into a structured "snapshot" that lists decisions, actions, questions, risks, and the next check-in.
-- Serves summaries generated either by deterministic heuristics (`logic` provider) or an external LLM provider (`fake`, `openai`, or future integrations) with automatic fallback to the logic baseline if model assist fails.
-- Caches the most recent snapshot per client IP so that users can immediately download the rendered Markdown export.
-- Exposes Prometheus-formatted counters to track request volume, provider mix, rate limiting, and LLM usage.
+## Service overview
+- Flask app that renders the meeting transcript form at `/` and processes submissions at `/snap`.
+- Snapshot extraction runs through one provider at a time: `logic` (deterministic), `fake` (static sample), or `openai` (live API with logic fallback on failure).
+- Prometheus-formatted counters are exposed at `/metrics` for request volume, provider mix, limiter activity, and model usage.
 
-## Endpoints
-| Method | Path | Description |
+## Configuration quick reference
+| Variable | Default | Purpose |
 | --- | --- | --- |
-| GET | `/` | Render the transcript form and the current snapshot preview. |
-| POST | `/snap` | Accept a transcript submission, enforce rate limits, call the configured provider, and render the updated snapshot. |
-| GET | `/download.md` | Download the last snapshot for the caller as Markdown, returning 404 when nothing is cached. |
-| GET | `/metrics` | Prometheus metrics for `requests_total`, `snaps_total{path=...}`, rate-limit hits, and LLM latency/token counters. |
-
-## Environment variables
-| Name | Default | Purpose |
-| --- | --- | --- |
-| `MEETING_SNAP_PROVIDER` | `logic` | Provider ID (`logic`, `fake`, `openai`, or another custom provider) used when `/snap` receives input. |
-| `MEETING_SNAP_TIMEOUT_MS` | `10000` | Deadline in milliseconds passed to remote providers. Ignored by the `logic` baseline. |
-| `MEETING_SNAP_MAX_CHARS` | `8000` | Maximum characters accepted from the transcript form. Submissions beyond the limit render an error. |
-| `MEETING_SNAP_RATE_LIMIT` | `30` | Number of `/snap` requests allowed per identity during the configured window. Set to `0` to block all writes. |
-| `MEETING_SNAP_RATE_WINDOW_S` | `86400` | Size of the sliding rate-limit window in seconds. |
-| `OPENAI_MODEL` | `gpt-4o-mini` | OpenAI model name when `MEETING_SNAP_PROVIDER=openai`.
-
-## Starting the service
-- **Local development:** `python -m t008_meeting_snap.app` (uses the built-in Flask development server with debug logging enabled).
-- **Hosted / production:** `gunicorn t008_meeting_snap.app:app --bind 0.0.0.0:$PORT --workers 2 --threads 4` (matches the `Procfile` used by platforms that support process definitions).
+| `MEETING_SNAP_PROVIDER` | `logic` | Controls which extractor runs when `/snap` receives input. |
+| `MEETING_SNAP_TIMEOUT_MS` | `10000` | Deadline passed to external providers. Ignored by `logic`. |
+| `MEETING_SNAP_MAX_CHARS` | `8000` | Maximum transcript length accepted from the form. |
+| `MEETING_SNAP_RATE_LIMIT` | `30` | Requests allowed per identity during one window. |
+| `MEETING_SNAP_RATE_WINDOW_S` | `86400` | Sliding window size, in seconds, for rate limiting. |
+| `OPENAI_API_KEY` | _(none)_ | Required when the provider is `openai`; read directly by the `openai` SDK. |
+| `OPENAI_MODEL` | `gpt-4o-mini` | Overrides the OpenAI model used for extraction. |
 
 ## Runbook
-### LLM provider degraded or unavailable
-1. Confirm alerts by checking `/metrics` for a spike in `snaps_total{path="fallback"}` or drops in `llm_calls_total`/`llm_latency_ms_sum`.
-2. Review application logs for `fallback` reasons or provider-specific errors.
-3. The service already falls back to the `logic` baseline for each affected request. If the provider outage is prolonged, temporarily force logic-only mode (see below) to stop generating failing LLM traffic.
-4. Once the provider is healthy, revert to the original configuration and monitor that `snaps_total{path="fallback"}` returns to baseline.
 
-### Temporary rate-limit increase
-1. Evaluate `/metrics` to confirm rate-limit saturation (`rate_limit_hits_total`).
-2. Pick a new limit/window pair that preserves downstream capacity.
-3. Update `MEETING_SNAP_RATE_LIMIT` and/or `MEETING_SNAP_RATE_WINDOW_S` in the deployment environment. Reloading the process is enough for changes to take effect—the limiter instance is rebuilt from the new config when `/snap` handles the next request.
-4. Monitor `rate_limit_hits_total` to ensure the new ceiling unblocks legitimate traffic.
-5. Remember to roll back the change when demand normalizes.
+### Rotate the OpenAI API key
+1. Generate an OpenAI API key and store it in the deployment secret manager.
+2. Update the environment variable `OPENAI_API_KEY` for the running service (container env, process manager config, or `.env` file).
+3. Restart or redeploy the process so the `openai` client picks up the new key.
+4. Submit a short transcript while `MEETING_SNAP_PROVIDER=openai` or inspect `/metrics` to confirm `snaps_total{path="openai"}` increments without errors.
 
-### Force logic-only mode
-1. Set `MEETING_SNAP_PROVIDER=logic` in the runtime environment. This disables LLM calls and ensures every `/snap` request uses deterministic extraction.
-2. Optionally drop any cached snapshots if you need to avoid stale mixed-provider content.
-3. Notify stakeholders that the UI banner will show "Model assist: OFF" until the provider setting is restored.
-4. When the upstream model is healthy again, revert the provider setting and spot-check `/snap` responses for model-assisted output.
+### Force the logic provider
+1. Set `MEETING_SNAP_PROVIDER=logic` in the runtime environment.
+2. Restart the process (the provider is read during request handling, so a reload ensures the new value is active for every worker).
+3. Verify by loading `/` and confirming the banner shows "Model assist: OFF", or check `/metrics` for `snaps_total{path="logic"}` growth only.
 
-## SLOs
-- **Availability:** 99% of `/snap` requests per day should return HTTP 200. Track this by comparing total requests to 4xx/5xx counts in logs; unexpected spikes in `snaps_total{path="fallback"}` can hint at hidden errors.
-- **Model-assist success:** Maintain at least 95% of snapshots served via LLM providers (`snaps_total{path="openai"}` or other providers) over fallback during a rolling 1-hour window.
-- **Rate limiting:** Keep `rate_limit_hits_total / requests_total` under 1% per hour. Adjust limits or investigate abusive clients when the ratio grows.
-- **Latency:** Average LLM latency (`llm_latency_ms_sum / llm_calls_total`) should stay below the configured timeout. Investigate if the value approaches the `MEETING_SNAP_TIMEOUT_MS` ceiling for prolonged periods.
+### Bump the rate limit
+1. Decide on the new `MEETING_SNAP_RATE_LIMIT` (requests) and, if needed, `MEETING_SNAP_RATE_WINDOW_S` (window length in seconds).
+2. Update those environment variables wherever the service is configured.
+3. Restart the process so a fresh `RateLimiter` is created with the new values.
+4. Monitor `/metrics` and watch `rate_limit_hits_total` to ensure the new ceiling alleviates throttling.
+
+### Check `/metrics`
+1. Issue `curl http://<host>:<port>/metrics` (or visit the URL in a browser) to retrieve the Prometheus text payload.
+2. Key counters:
+   - `requests_total` – all HTTP requests handled.
+   - `snaps_total{path="logic"|"fake"|"openai"|"fallback"}` – provider usage and fallback volume.
+   - `rate_limit_hits_total` – rejected submissions due to throttling.
+   - `llm_calls_total`, `llm_latency_ms_sum`, `llm_tokens_total` – external model usage when `openai` is active.


### PR DESCRIPTION
## Summary
- expand the README with a Run / Test / Env quickstart, matching the current environment variables and commands
- replace the operations guide with a concise runbook covering key env vars, rotating OpenAI keys, forcing logic mode, rate limit changes, and /metrics checks
- streamline the development guide with an updated repo map, JSON contract table, stub location call-outs, and coding rules

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68caaf9e66048326b9f185cc44c46158