### PR TITLE
Improve fallback and metrics smoke tests

### DIFF
--- a/tests/test_extractor_fallback.py
+++ b/tests/test_extractor_fallback.py
@@ -1,6 +1,8 @@
 """Ensure the app falls back to baseline extraction on provider errors."""
 
-from t008_meeting_snap import extractor
+from importlib import reload
+
+from t008_meeting_snap import extractor, metrics
 from t008_meeting_snap.app import app
 
 app.config.update(TESTING=True)
@@ -9,6 +11,7 @@ app.config.update(TESTING=True)
 def test_snap_falls_back_when_provider_errors(monkeypatch) -> None:
     """A provider failure returns a baseline snapshot with the assist note."""
 
+    reload(metrics)
     monkeypatch.setenv("MEETING_SNAP_PROVIDER", "openai")
 
     def boom(text: str, provider_id: str, timeout_ms: int) -> dict[str, object]:
@@ -18,8 +21,12 @@ def test_snap_falls_back_when_provider_errors(monkeypatch) -> None:
 
     with app.test_client() as client:
         response = client.post("/snap", data={"transcript": "Daily sync summary."})
+        metrics_response = client.get("/metrics")
+        assert metrics_response.status_code == 200
+        body = response.get_data(as_text=True)
+        metrics_body = metrics_response.get_data(as_text=True)
 
     assert response.status_code == 200
-    body = response.get_data(as_text=True)
     assert "Model assist: OFF" in body
     assert "Model assist unavailable—using baseline." in body
+    assert "snaps_total{path=\"fallback\"} 1" in metrics_body

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -28,13 +28,9 @@ def test_metrics_increment_after_snap(monkeypatch) -> None:
     monkeypatch.setenv("MEETING_SNAP_PROVIDER", "logic")
 
     with app_module.app.test_client() as client:
-        before = _collect_metrics(client)
         post_response = client.post("/snap", data={"transcript": "Brief hello."})
         assert post_response.status_code == 200
-        after = _collect_metrics(client)
+        payload = _collect_metrics(client)
 
-    assert after["requests_total"] == before["requests_total"] + 2
-    assert (
-        after['snaps_total{path="logic"}']
-        == before['snaps_total{path="logic"}'] + 1
-    )
+    assert payload["requests_total"] == 2
+    assert payload['snaps_total{path="logic"}'] == 1


### PR DESCRIPTION
## Summary
- reset the metrics module in the fallback smoke test and verify the Prometheus payload records the fallback path
- tighten the metrics smoke test to assert request and logic snap counters after a single POST

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cabdbe80e08326bebac88bca1a3726