### PR TITLE
Fix OpenAI adapter timeout handling and improve fallback logging

### DIFF
--- a/t008_meeting_snap/extractor.py
+++ b/t008_meeting_snap/extractor.py
@@ -1,6 +1,8 @@
 """Snapshot extraction orchestrator for Meeting Snap."""
 from __future__ import annotations
 
+import logging
+
 from typing import Dict, Tuple
 
 from . import config, llm_fake, llm_openai, logic, schema
@@ -26,6 +28,7 @@ def extract_snapshot(
             snapshot = schema.validate_snapshot(candidate)
             return snapshot, True
     except Exception:
+        logging.exception("Provider '%s' failed; falling back to logic baseline", provider_id or "")
         fallback = logic.assemble(text)
         snapshot = schema.validate_snapshot(fallback)
         return snapshot, False

--- a/t008_meeting_snap/llm_openai.py
+++ b/t008_meeting_snap/llm_openai.py
@@ -37,7 +37,7 @@ def _create_client(timeout_s: float | None):
 def _call_openai(client, *, model: str, prompt: str, timeout_s: float | None) -> str:
     try:
         return _call_responses_api(client, model=model, prompt=prompt, timeout_s=timeout_s)
-    except AttributeError:
+    except Exception:
         return _call_chat_completions_api(client, model=model, prompt=prompt, timeout_s=timeout_s)
 
 
@@ -48,8 +48,6 @@ def _call_responses_api(client, *, model: str, prompt: str, timeout_s: float | N
         "input": prompt,
         "response_format": {"type": "json_object"},
     }
-    if timeout_s is not None:
-        kwargs["timeout"] = timeout_s
     response = responses.create(**kwargs)
 
     output_text = getattr(response, "output_text", None)
@@ -80,14 +78,13 @@ def _call_chat_completions_api(client, *, model: str, prompt: str, timeout_s: fl
         "model": model,
         "messages": [{"role": "user", "content": prompt}],
     }
-    if timeout_s is not None:
-        kwargs["timeout"] = timeout_s
     kwargs["response_format"] = {"type": "json_object"}
 
     try:
         completion = completions.create(**kwargs)
     except TypeError:
         kwargs.pop("response_format", None)
+        kwargs.pop("timeout", None)
         completion = completions.create(**kwargs)
 
     choices = getattr(completion, "choices", None)


### PR DESCRIPTION
## Summary
- rely on the client-level timeout when calling the OpenAI Responses API and broaden fallback to chat completions on any failure
- make the chat completions fallback resilient to stray timeout kwargs
- log provider exceptions before returning the logic baseline snapshot

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caf2a3654c8326accbeb4426b620a4