### PR TITLE
Add OpenAI provider instrumentation tests and richer logging

### DIFF
--- a/t008_meeting_snap/extractor.py
+++ b/t008_meeting_snap/extractor.py
@@ -27,8 +27,13 @@ def extract_snapshot(
             candidate = _extract_with_provider(text, provider_id, timeout_ms)
             snapshot = schema.validate_snapshot(candidate)
             return snapshot, True
-    except Exception:
-        logging.exception("Provider '%s' failed; falling back to logic baseline", provider_id or "")
+    except Exception as exc:
+        logging.exception(
+            "Provider '%s' failed; falling back to logic baseline: %s: %s",
+            provider_id or "",
+            type(exc).__name__,
+            str(exc)[:300],
+        )
         fallback = logic.assemble(text)
         snapshot = schema.validate_snapshot(fallback)
         return snapshot, False

--- a/tests/test_app_provider_integration.py
+++ b/tests/test_app_provider_integration.py
@@ -1,0 +1,69 @@
+"""Integration checks for provider success and failure flows in the Flask app."""
+
+from __future__ import annotations
+
+from importlib import reload
+
+from t008_meeting_snap import llm_openai
+from t008_meeting_snap import app as app_module
+from t008_meeting_snap import metrics as metrics_module
+
+app_module.app.config.update(TESTING=True)
+
+
+def _reset_metrics():
+    metrics = reload(metrics_module)
+    app_module.metrics = metrics
+    return metrics
+
+
+def _client():
+    app_module.app.config["TESTING"] = True
+    if hasattr(app_module, "_SNAPSHOT_CACHE"):
+        app_module._SNAPSHOT_CACHE.clear()
+    return app_module.app.test_client()
+
+
+def test_openai_success_shows_badge_and_metrics(monkeypatch):
+    metrics = _reset_metrics()
+    monkeypatch.setenv("MEETING_SNAP_PROVIDER", "openai")
+    monkeypatch.setattr(
+        llm_openai,
+        "extract",
+        lambda *_: {
+            "decisions": ["A"],
+            "actions": [],
+            "questions": [],
+            "risks": [],
+            "next_checkin": None,
+        },
+    )
+
+    client = _client()
+    before = dict(metrics.snaps_total)
+    response = client.post("/snap", data={"transcript": "x"})
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "Model assist: ON" in html
+    after = dict(metrics.snaps_total)
+    assert after.get("openai", 0) == before.get("openai", 0) + 1
+
+
+def test_openai_failure_shows_banner_and_fallback(monkeypatch):
+    metrics = _reset_metrics()
+    monkeypatch.setenv("MEETING_SNAP_PROVIDER", "openai")
+    monkeypatch.setattr(
+        llm_openai,
+        "extract",
+        lambda *_: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    client = _client()
+    before = dict(metrics.snaps_total)
+    response = client.post("/snap", data={"transcript": "x"})
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "Model assist: OFF" in html
+    assert "Model assist unavailable" in html
+    after = dict(metrics.snaps_total)
+    assert after.get("fallback", 0) == before.get("fallback", 0) + 1

--- a/tests/test_extractor_provider_paths.py
+++ b/tests/test_extractor_provider_paths.py
@@ -1,0 +1,50 @@
+"""Regression tests for extractor behaviour across provider paths."""
+
+from __future__ import annotations
+
+import logging
+
+from t008_meeting_snap import extractor, llm_openai, schema
+
+
+def test_extractor_success_sets_used_true(monkeypatch, caplog):
+    monkeypatch.setattr(
+        llm_openai,
+        "extract",
+        lambda *_: {
+            "decisions": ["A"],
+            "actions": [],
+            "questions": [],
+            "risks": [],
+            "next_checkin": None,
+        },
+    )
+
+    with caplog.at_level(logging.INFO):
+        snapshot, used = extractor.extract_snapshot("t", "openai", 3000)
+
+    assert used is True
+    assert schema.validate_snapshot(snapshot)["decisions"] == ["A"]
+
+
+def test_extractor_failure_logs_and_falls_back(monkeypatch, caplog):
+    def boom(*_):
+        raise RuntimeError("fake provider error")
+
+    monkeypatch.setattr(llm_openai, "extract", boom)
+
+    with caplog.at_level(logging.ERROR):
+        snapshot, used = extractor.extract_snapshot("t", "openai", 3000)
+
+    assert used is False
+    assert any(
+        "Provider 'openai' failed" in record.getMessage() for record in caplog.records
+    )
+    validated = schema.validate_snapshot(snapshot)
+    assert set(validated.keys()) == {
+        "decisions",
+        "actions",
+        "questions",
+        "risks",
+        "next_checkin",
+    }

--- a/tests/test_llm_openai_adapter.py
+++ b/tests/test_llm_openai_adapter.py
@@ -1,0 +1,139 @@
+"""Unit tests covering the OpenAI adapter response shape handling."""
+
+from __future__ import annotations
+
+import json
+import types
+
+import pytest
+
+from t008_meeting_snap import llm, llm_openai, schema
+
+GOOD_JSON = json.dumps(
+    {
+        "decisions": ["Ship pilot"],
+        "actions": [
+            {"action": "Email ACME", "owner": "Graham", "due": "tomorrow"}
+        ],
+        "questions": ["What about GDPR?"],
+        "risks": ["Scope creep"],
+        "next_checkin": "Tue 4pm",
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def stub_prompt(monkeypatch):
+    monkeypatch.setattr(llm, "build_prompt", lambda transcript: transcript)
+
+
+def fake_client_responses_output_text():
+    client = types.SimpleNamespace()
+
+    class Responses:
+        def create(self, **kwargs):  # noqa: D401 - simple stub
+            return types.SimpleNamespace(output_text=GOOD_JSON)
+
+    client.responses = Responses()
+    return client
+
+
+def fake_client_responses_output_list():
+    client = types.SimpleNamespace()
+
+    class Responses:
+        def create(self, **kwargs):  # noqa: D401 - simple stub
+            content = [{"text": GOOD_JSON}]
+            item = types.SimpleNamespace(content=content)
+            return types.SimpleNamespace(output=[item])
+
+    client.responses = Responses()
+    return client
+
+
+def fake_client_chat_completions():
+    client = types.SimpleNamespace()
+
+    class ChatCompletions:
+        def create(self, **kwargs):  # noqa: D401 - simple stub
+            return {"choices": [{"message": {"content": GOOD_JSON}}]}
+
+    class Chat:
+        def __init__(self):
+            self.completions = ChatCompletions()
+
+    client.chat = Chat()
+    return client
+
+
+@pytest.mark.parametrize(
+    "client_factory",
+    [fake_client_responses_output_text, fake_client_responses_output_list],
+)
+def test_responses_api_shapes(monkeypatch, client_factory):
+    monkeypatch.setattr(
+        llm_openai, "_create_client", lambda timeout_s: client_factory()
+    )
+    data = llm_openai.extract("transcript", timeout_ms=3000, model="gpt-4o-mini")
+    snap = schema.validate_snapshot(data)
+    assert set(snap.keys()) == {
+        "decisions",
+        "actions",
+        "questions",
+        "risks",
+        "next_checkin",
+    }
+    assert snap["decisions"] and snap["actions"]
+
+
+def test_fallback_to_chat_when_responses_raises(monkeypatch):
+    def bad_client(_timeout):
+        client = fake_client_chat_completions()
+
+        class BadResponses:
+            def create(self, **kwargs):  # noqa: D401 - simple stub
+                raise RuntimeError("responses unavailable")
+
+        client.responses = BadResponses()
+        return client
+
+    monkeypatch.setattr(llm_openai, "_create_client", bad_client)
+    data = llm_openai.extract("t", timeout_ms=3000, model="gpt-4o-mini")
+    snap = schema.validate_snapshot(data)
+    assert snap["decisions"]
+
+
+def test_json_wrapped_text_parses(monkeypatch):
+    client = fake_client_responses_output_text()
+
+    class Responses:
+        def create(self, **kwargs):  # noqa: D401 - simple stub
+            return types.SimpleNamespace(output_text=f"Here you go:\n{GOOD_JSON}\nThanks!")
+
+    client.responses = Responses()
+    monkeypatch.setattr(llm_openai, "_create_client", lambda _: client)
+    data = llm_openai.extract("t", timeout_ms=3000, model="gpt-4o-mini")
+    assert schema.validate_snapshot(data)["decisions"]
+
+
+def test_adapter_raises_when_both_apis_fail(monkeypatch):
+    class BadClient:
+        class Responses:
+            def create(self, **kwargs):  # noqa: D401 - simple stub
+                raise RuntimeError("no responses")
+
+        class Chat:
+            class Completions:
+                def create(self, **kwargs):  # noqa: D401 - simple stub
+                    raise RuntimeError("no chat")
+
+            def __init__(self):
+                self.completions = self.Completions()
+
+        def __init__(self):
+            self.responses = self.Responses()
+            self.chat = self.Chat()
+
+    monkeypatch.setattr(llm_openai, "_create_client", lambda _: BadClient())
+    with pytest.raises(Exception):
+        llm_openai.extract("t", timeout_ms=3000, model="gpt-4o-mini")


### PR DESCRIPTION
## Summary
- add unit tests that exercise the OpenAI adapter response shapes, fallback, and error propagation
- cover extractor success and failure paths to assert logging and baseline fallback behaviour
- add Flask integration tests for OpenAI success/failure UI + metrics and include richer exception detail in provider fallback logging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caf7357e4483268d6a87df35ee0892